### PR TITLE
Only ignore toplevel folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-proprietary/
+/proprietary/


### PR DESCRIPTION
The current gitignore would also ignore prebuilt/proprietary

Solution found here:
http://stackoverflow.com/questions/3637660/how-to-exclude-file-only-from-root-folder-in-git